### PR TITLE
Feature/refactor gitlab factory

### DIFF
--- a/src/main/groovy/com/pst/asseco/channels/devops/Main.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/Main.groovy
@@ -1,15 +1,11 @@
 package com.pst.asseco.channels.devops
 
-import com.pst.asseco.channels.devops.http.RepoExplorerFactory
 import com.pst.asseco.channels.devops.infrastructure.Einstein
 import com.pst.asseco.channels.devops.infrastructure.cli.CliParser
 import com.pst.asseco.channels.devops.infrastructure.utils.Console
 import groovy.json.JsonBuilder
 
 class Main {
-
-    static final String GITLAB_URL = "GITLAB_URL"
-    static final String GITLAB_TOKEN = "GITLAB_TOKEN"
 
     static CliParser cliParser
 
@@ -26,9 +22,7 @@ class Main {
         }
 
         try {
-            // set the repository to look for
-            checkGitlabEnvVariables()
-            RepoExplorerFactory.create(RepoExplorerFactory.Type.GITLAB, System.getenv(GITLAB_URL), System.getenv(GITLAB_TOKEN))
+
             Einstein.calcDependencies(cliParser.einsteinOptions.projects)
 
             String outputFilePath = cliParser.einsteinOptions.saveToFile
@@ -42,20 +36,11 @@ class Main {
         Console.print("Finished!")
     }
 
-    static private void checkGitlabEnvVariables() {
-
-        if(!System.getenv(GITLAB_URL))
-            throw new IllegalArgumentException("Environment variable '$GITLAB_URL' is undefined.")
-        if(!System.getenv(GITLAB_TOKEN))
-            throw new IllegalArgumentException("Environment variable '$GITLAB_TOKEN' is undefined.")
-
-    }
-
     static private void saveResultsIntoFile(String aFilePath) {
 
         try {
             Console.info("Saving dependencies into file ${aFilePath}")
-            new File(aFilePath).write(new JsonBuilder(Einstein.getCollectedDependencies()).toPrettyString())
+            new File(aFilePath).write(new JsonBuilder(Einstein.getCalculatedDependencies()).toPrettyString())
         } catch (e) {
             Console.err("Unable to save results into output file '${aFilePath}'. Cause: ${e}")
             System.exit(1)

--- a/src/main/groovy/com/pst/asseco/channels/devops/http/GitLabRepositoryExplorer.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/http/GitLabRepositoryExplorer.groovy
@@ -72,26 +72,6 @@ class GitLabRepositoryExplorer extends RepositoryExplorer {
 
     }
 
-    /**
-     *  Returns a project's Http URL given its namespace (ie. group) and its project name
-     *
-     * @param the namespace of the project (ie. group)
-     * @param the name of the project
-     * @return the HTTP URL to the project repository
-     */
-    @Override
-    String getHttpUrlToRepo(String namespace, String projectName) {
-
-        try {
-            Project project = findProject(namespace, projectName)
-            return project.getHttpUrlToRepo()
-        } catch (Exception e) {
-            Console.err("Could not get Http URL to Repo for project $namespace/$projectName. Cause: $e")
-            throw e
-        }
-
-    }
-
     String getRepoWebUrl(String namespace, String projectName) {
         try {
             Project project = findProject(namespace, projectName)

--- a/src/main/groovy/com/pst/asseco/channels/devops/http/GitLabRepositoryExplorer.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/http/GitLabRepositoryExplorer.groovy
@@ -16,8 +16,15 @@ class GitLabRepositoryExplorer extends RepositoryExplorer {
 
     GitLabApi api
 
-    GitLabRepositoryExplorer(String aRepoUrl, String aToken) {
-        super(aRepoUrl, aToken)
+
+    @Override
+    protected void setRepoURLEnvVar() {
+        repoURLEnvVar = "GITLAB_URL"
+    }
+
+    @Override
+    protected void setTokenEnvVar() {
+        tokenEnvVar = "GITLAB_TOKEN"
     }
 
     @Override

--- a/src/main/groovy/com/pst/asseco/channels/devops/http/RepoExplorerFactory.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/http/RepoExplorerFactory.groovy
@@ -1,4 +1,7 @@
 package com.pst.asseco.channels.devops.http
+
+import com.pst.asseco.channels.devops.infrastructure.utils.Console
+
 /**
  * This class wraps up the Repository Explorer instance, assuring that the same instance is used through all
  * the application
@@ -11,14 +14,28 @@ abstract class RepoExplorerFactory {
 
     private static RepositoryExplorer instance
 
-    static RepositoryExplorer create(Type aRepoType, String aRepoUrl, String aToken) {
+    /**
+     * Creates a Gitlab Api explorer
+     *
+     * Currently, only Gitlab is supported. In the future,
+     * by supporting more Repos, the Repository Explorer tool must be configured
+     * by the user through an environment variable (i.e REPO_TOOL) and must be dynamically loaded on this method.
+     *
+     * @return Gitlab Api instance
+     */
+    static RepositoryExplorer create() {
+        Console.debug("Instantiating Gitlab Api...")
+        return create(Type.GITLAB)
+    }
+
+    static RepositoryExplorer create(Type aRepoType) {
 
         switch (aRepoType) {
             case Type.GITLAB:
-                instance = new GitLabRepositoryExplorer(aRepoUrl, aToken)
+                instance = new GitLabRepositoryExplorer()
                 break
 //            case Type.GITHUB:
-//                instance = new GitHubRepositoryExplorer(aRepoUrl, aToken)
+//                instance = new GitHubRepositoryExplorer()
 //                break
         }
 

--- a/src/main/groovy/com/pst/asseco/channels/devops/http/RepositoryExplorer.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/http/RepositoryExplorer.groovy
@@ -6,14 +6,40 @@ import java.util.function.Predicate
 
 abstract class RepositoryExplorer {
 
-    String repoUrl
-    String token
 
-    protected RepositoryExplorer(String aRepoUrl, String aToken) {
-        repoUrl = aRepoUrl
-        token = aToken
+    protected String repoURLEnvVar
+    protected String tokenEnvVar
+
+    protected String repoUrl
+    protected String token
+
+    protected RepositoryExplorer() {
+
+        setRepoURLEnvVar()
+        setTokenEnvVar()
+
+        loadRepoUrl()
+        loadAccessToken()
 
         connect()
+    }
+
+    protected abstract void setRepoURLEnvVar()
+    protected abstract void setTokenEnvVar()
+
+    protected void loadRepoUrl() {
+
+        repoUrl = System.getenv(repoURLEnvVar)
+        if(!repoUrl)
+            throw new IllegalArgumentException("Environment variable '$repoURLEnvVar' is undefined.")
+
+    }
+
+    protected void loadAccessToken() {
+
+        token = System.getenv(tokenEnvVar)
+        if(!token)
+            throw new IllegalArgumentException("Environment variable '$tokenEnvVar' is undefined.")
     }
 
     abstract void connect()

--- a/src/main/groovy/com/pst/asseco/channels/devops/http/RepositoryExplorer.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/http/RepositoryExplorer.groovy
@@ -22,8 +22,6 @@ abstract class RepositoryExplorer {
 
     abstract String getRepoWebUrl(String namespace, String projectName)
 
-    abstract String getHttpUrlToRepo(String namespace, String projectName)
-
     abstract String getFileContents(String filePath, String ref, String namespace, String projectName)
 
     abstract String getTagHash(String tagName, String namespace, String projectName)

--- a/src/main/groovy/com/pst/asseco/channels/devops/infrastructure/DependenciesManager.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/infrastructure/DependenciesManager.groovy
@@ -5,7 +5,7 @@ import com.pst.asseco.channels.devops.infrastructure.version.Version
 
 class DependenciesManager {
 
-    Map finalDependencies = [:]
+    Map calcDependencies = [:]
 
     private Map projectsByIndex = [:]
     private Map readDependencies = [:]
@@ -82,7 +82,7 @@ class DependenciesManager {
                 dependencies.addAll(project.getDependencies())
 
             filterAcceptedDependencies(dependencies).each { acceptedDependency ->
-                finalDependencies.put(acceptedDependency.id, acceptedDependency.version.toString())
+                calcDependencies.put(acceptedDependency.id, acceptedDependency.version.toString())
             }
         }
     }
@@ -96,7 +96,7 @@ class DependenciesManager {
             if (dependentVersions.size() <= 1)
                 return
 
-            Console.warn("Identified multiple versions for Project ${projectName}. Are they compatible? Let's check...")
+            Console.warn("Checking if the multiple versions found for Project ${projectName} are semantically compatible...")
 
             if (hasNonCompatibleVersions(dependentVersions)) {
                 Console.warn("Found non compatible versions for Project '${projectName}': ${dependentVersions.join(" <> ")}")
@@ -150,7 +150,7 @@ class DependenciesManager {
 
     private void printRawDependencies() {
 
-        Console.info("Check raw dependencies:\n")
+        Console.info("Raw dependencies list:\n")
         projectsByIndex.each { p ->
             String projectRef = p.key
             Project project = (Project) p.value
@@ -164,7 +164,7 @@ class DependenciesManager {
             }
         }
         Console.print("\n")
-        Console.info("Check required dependencies by Project:")
+        Console.info("Calculated dependencies per Project:")
         Console.print("$readDependencies\n")
     }
 }

--- a/src/main/groovy/com/pst/asseco/channels/devops/infrastructure/Einstein.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/infrastructure/Einstein.groovy
@@ -1,5 +1,6 @@
 package com.pst.asseco.channels.devops.infrastructure
 
+import com.pst.asseco.channels.devops.http.RepoExplorerFactory
 import com.pst.asseco.channels.devops.infrastructure.cli.CliParser
 import com.pst.asseco.channels.devops.infrastructure.crawlers.ProjectsCrawler
 import com.pst.asseco.channels.devops.infrastructure.metrics.Metrics
@@ -57,28 +58,27 @@ abstract class Einstein {
 
     static void calcDependencies(List<ProjectDao> aProjectsData) {
 
-        Console.debug("Start tracking timer...")
+        RepoExplorerFactory.create()
+
         metrics.startTimeTracking(Metrics.METRIC.DEPENDENCIES_CALCULATION_DURATION)
 
         ProjectsCrawler pCrawler = new ProjectsCrawler(loadProjects(aProjectsData))
         pCrawler.start()
         pCrawler.join()
 
-        Console.debug("Stop tracking timer...")
         metrics.stopTimeTracking(Metrics.METRIC.DEPENDENCIES_CALCULATION_DURATION)
 
         dpManager.resolveVersions(scannedDependencies)
 
-        Console.info("Check cleaned dependencies:")
-        Console.print(dpManager.getFinalDependencies())
+        Console.info("Calculated dependencies:")
+        Console.print(dpManager.getCalcDependencies())
 
         Console.info("Einstein took " +
-                metrics.getTimeDuration(Metrics.METRIC.DEPENDENCIES_CALCULATION_DURATION).toString() +
-                " calculating required dependencies")
+                metrics.getTimeDuration(Metrics.METRIC.DEPENDENCIES_CALCULATION_DURATION).toString())
     }
 
-    static Map getCollectedDependencies() {
-        return dpManager.getFinalDependencies()
+    static Map getCalculatedDependencies() {
+        return dpManager.getCalcDependencies()
     }
 
     private static List<Project> loadProjects(List<ProjectDao> aProjectsData) {

--- a/src/main/groovy/com/pst/asseco/channels/devops/infrastructure/cli/EinsteinCliOptions.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/infrastructure/cli/EinsteinCliOptions.groovy
@@ -10,7 +10,7 @@ class EinsteinCliOptions {
     @Option(shortName = 'h', description = 'display usage')
     Boolean help
 
-    @Option(shortName = 'verbose', description = 'Show additional information along the dependencies calculation process')
+    @Option(shortName = 'verbose', description = 'Provide additional details')
     boolean verbose
 
     // --projects or -p

--- a/src/main/groovy/com/pst/asseco/channels/devops/infrastructure/metrics/Metrics.groovy
+++ b/src/main/groovy/com/pst/asseco/channels/devops/infrastructure/metrics/Metrics.groovy
@@ -1,5 +1,7 @@
 package com.pst.asseco.channels.devops.infrastructure.metrics
 
+import com.pst.asseco.channels.devops.infrastructure.utils.Console
+
 class Metrics {
 
     enum METRIC {
@@ -14,6 +16,7 @@ class Metrics {
 
     void startTimeTracking(METRIC aMETRIC) {
 
+        Console.debug("Start tracking timer for metric $aMETRIC...")
         Timer timer = new Timer()
         timers[aMETRIC] = timer
 
@@ -23,6 +26,8 @@ class Metrics {
     void stopTimeTracking(METRIC aMetric) {
 
         checkIfExistsTimer(aMetric)
+
+        Console.debug("Stop tracking timer for metric $aMetric...")
         ((Timer) timers[aMetric]).stop()
     }
 


### PR DESCRIPTION
The PR main's intent is to move all the Gitlab Api object creation logic from the `Main` class into the `Einstein` class. This code was in the wrong place. By using einstein as a dependency library instead of as an application, things would break.

This changes also apply some minor enhancements over the Repository Explorer Factory logic and output logs.

You can test these changes by invoking the application with argument `-p devops/foo:1.0.0`