### PR TITLE
Feature/fix semver fixed v versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Changed
+- Changed SemanticVersion class to fetch the equivalent tag version from Gitlab for a declared version.
 
 [1.1.0] - 2021-06-08
 ### Changed


### PR DESCRIPTION
### What does this do?
- This PR changes the SemanticVersion class logic in order to obtain the corresponding tag version from Gitlab for the declared version in einstein.yaml.

### How to test it
- Pull this branch, compile it and calculate dependencies for an einstein.yaml that contains declared versions instead of ranges or snapshots.